### PR TITLE
use fmt for string concatenation, move API base URIs in constans, fix status parsing

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,8 +2,9 @@ package mojango
 
 import (
 	"encoding/json"
+	"fmt"
+
 	"github.com/valyala/fasthttp"
-	"strconv"
 )
 
 // Client represents an API client
@@ -23,7 +24,8 @@ func New() *Client {
 // FetchStatus fetches the states of all Mojang services and wraps them into a single object
 func (client *Client) FetchStatus() (*Status, error) {
 	// Call the Mojang status endpoint
-	code, body, err := client.http.Get(nil, "https://status.mojang.com/check"); if err != nil {
+	code, body, err := client.http.Get(nil, fmt.Sprintf("%s/check", uriStatus))
+	if err != nil {
 		return nil, err
 	}
 
@@ -46,9 +48,10 @@ func (client *Client) FetchUUIDAtTime(username string, timestamp int64) (string,
 	// Call the Mojang profile endpoint
 	atExtension := ""
 	if timestamp >= 0 {
-		atExtension = "?at=" + strconv.FormatInt(timestamp, 10)
+		atExtension = fmt.Sprintf("?at=%d", timestamp)
 	}
-	code, body, err := client.http.Get(nil, "https://api.mojang.com/users/profiles/minecraft/" + username + atExtension); if err != nil {
+	code, body, err := client.http.Get(nil, fmt.Sprintf("%s/users/profiles/minecraft/%s%s", uriApi, username, atExtension))
+	if err != nil {
 		return "", err
 	}
 
@@ -59,7 +62,8 @@ func (client *Client) FetchUUIDAtTime(username string, timestamp int64) (string,
 
 	// Parse the result into a map containing the profile data
 	var result map[string]interface{}
-	err = json.Unmarshal(body, &result); if err != nil {
+	err = json.Unmarshal(body, &result)
+	if err != nil {
 		return "", err
 	}
 
@@ -72,8 +76,9 @@ func (client *Client) FetchMultipleUUIDs(usernames []string) (map[string]string,
 	// Define the request object
 	request := fasthttp.AcquireRequest()
 	defer fasthttp.ReleaseRequest(request)
-	request.SetRequestURI("https://api.mojang.com/profiles/minecraft")
-	reqBody, err := json.Marshal(usernames); if err != nil {
+	request.SetRequestURI(fmt.Sprintf("%s/profiles/minecraft", uriApi))
+	reqBody, err := json.Marshal(usernames)
+	if err != nil {
 		return nil, err
 	}
 	request.SetBody(reqBody)
@@ -83,7 +88,8 @@ func (client *Client) FetchMultipleUUIDs(usernames []string) (map[string]string,
 	defer fasthttp.ReleaseResponse(response)
 
 	// Call the Mojang profile endpoint
-	err = client.http.Do(request, response); if err != nil {
+	err = client.http.Do(request, response)
+	if err != nil {
 		return nil, err
 	}
 
@@ -97,11 +103,12 @@ func (client *Client) FetchMultipleUUIDs(usernames []string) (map[string]string,
 	}
 
 	// Parse the response body into a list of results
-	var rawResults []struct{
+	var rawResults []struct {
 		UUID string `json:"id"`
 		Name string `json:"name"`
 	}
-	err = json.Unmarshal(body, &rawResults); if err != nil {
+	err = json.Unmarshal(body, &rawResults)
+	if err != nil {
 		return nil, err
 	}
 
@@ -116,7 +123,8 @@ func (client *Client) FetchMultipleUUIDs(usernames []string) (map[string]string,
 // FetchNameHistory fetches all names of the given UUID and their corresponding changing timestamps
 func (client *Client) FetchNameHistory(uuid string) ([]NameHistoryEntry, error) {
 	// Call the Mojang profile endpoint
-	code, body, err := client.http.Get(nil, "https://api.mojang.com/user/profiles/" + uuid + "/names"); if err != nil {
+	code, body, err := client.http.Get(nil, fmt.Sprintf("%s/user/profiles/%s/names", uriApi, uuid))
+	if err != nil {
 		return nil, err
 	}
 
@@ -127,7 +135,8 @@ func (client *Client) FetchNameHistory(uuid string) ([]NameHistoryEntry, error) 
 
 	// Parse the response body into a list of name history entries and return it
 	var entries []NameHistoryEntry
-	err = json.Unmarshal(body, &entries); if err != nil {
+	err = json.Unmarshal(body, &entries)
+	if err != nil {
 		return nil, err
 	}
 	return entries, nil
@@ -136,7 +145,8 @@ func (client *Client) FetchNameHistory(uuid string) ([]NameHistoryEntry, error) 
 // FetchProfile fetches the profile of the given UUID
 func (client *Client) FetchProfile(uuid string, unsigned bool) (*Profile, error) {
 	// Call the Mojang profile endpoint
-	code, body, err := client.http.Get(nil, "https://sessionserver.mojang.com/session/minecraft/profile/" + uuid + "?unsigned=" + strconv.FormatBool(unsigned)); if err != nil {
+	code, body, err := client.http.Get(nil, fmt.Sprintf("%s/session/minecraft/profile/%s?unsigned=%t", uriSession, uuid, unsigned))
+	if err != nil {
 		return nil, err
 	}
 
@@ -147,7 +157,8 @@ func (client *Client) FetchProfile(uuid string, unsigned bool) (*Profile, error)
 
 	// Parse the response body into a profile and return it
 	profile := new(Profile)
-	err = json.Unmarshal(body, profile); if err != nil {
+	err = json.Unmarshal(body, profile)
+	if err != nil {
 		return nil, err
 	}
 	return profile, nil

--- a/const.go
+++ b/const.go
@@ -1,0 +1,7 @@
+package mojango
+
+const (
+	uriStatus  = "https://status.mojang.com"
+	uriApi     = "https://api.mojang.com"
+	uriSession = "https://sessionserver.mojang.com"
+)

--- a/status.go
+++ b/status.go
@@ -4,62 +4,63 @@ import "encoding/json"
 
 // These constants represent the possible states of the Mojang services
 const (
-	StatusGreen = "green"
+	StatusGreen  = "green"
 	StatusYellow = "yellow"
-	StatusRed = "red"
+	StatusRed    = "red"
 )
 
 // Status contains all states of the Mojang services
 type Status struct {
 	MinecraftWebsite string
-	MojangWebsite string
-	Session string
-	SessionServer string
-	AuthServer string
-	Account string
-	Textures string
-	API string
+	MojangWebsite    string
+	Session          string
+	SessionServer    string
+	AuthServer       string
+	Account          string
+	Textures         string
+	API              string
 }
 
 // parseStatusFromBody parses a status object from the response body of the API
 func parseStatusFromBody(body []byte) (*Status, error) {
 	// Parse multiple single states out of the response body
-	var rawStates []struct{
-		Key string
-		Status string
-	}
-	err := json.Unmarshal(body, &rawStates); if err != nil {
+	var rawStates []map[string]string
+
+	err := json.Unmarshal(body, &rawStates)
+	if err != nil {
 		return nil, err
 	}
 
 	// Create the status object and put the corresponding values in it
 	status := new(Status)
-	for _, state := range rawStates {
-		switch state.Key {
-		case "minecraft.net":
-			status.MinecraftWebsite = state.Status
-			break
-		case "mojang.com":
-			status.MojangWebsite = state.Status
-			break
-		case "session.minecraft.net":
-			status.Session = state.Status
-			break
-		case "sessionserver.mojang.com":
-			status.SessionServer = state.Status
-			break
-		case "authserver.mojang.com":
-			status.AuthServer = state.Status
-			break
-		case "account.mojang.com":
-			status.Account = state.Status
-			break
-		case "textures.minecraft.net":
-			status.Textures = state.Status
-			break
-		case "api.mojang.com":
-			status.API = state.Status
-			break
+	for _, stateMap := range rawStates {
+		for key, state := range stateMap {
+			switch key {
+			case "minecraft.net":
+				status.MinecraftWebsite = state
+				break
+			case "mojang.com":
+				status.MojangWebsite = state
+				break
+			case "session.minecraft.net":
+				status.Session = state
+				break
+			case "sessionserver.mojang.com":
+				status.SessionServer = state
+				break
+			case "authserver.mojang.com":
+				status.AuthServer = state
+				break
+			case "account.mojang.com":
+				status.Account = state
+				break
+			case "textures.minecraft.net":
+				status.Textures = state
+				break
+			case "api.mojang.com":
+				status.API = state
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
First of all, nice project. Really want to support this a bit. ;)

At first, I've moved all API endpoint base URIs into constat variables in a seperated file `const.go`. This makes it a bit more maintainable and you have a better overview over all endpoints which are wrapped.

After that, I've changed all string concatenations to `fmt.Sprintf` calls, which is way more efficient than raw string concatenation, because [`fmt.Sprintf` is using `sync.Pool`](https://github.com/golang/go/blob/bb929b7452b5b8a6a584a94a110c98b0c6543a6e/src/fmt/print.go#L131) to avoid unnessecary memory allocations.
I know, the performance change is maginally on small scale, but it synergizes well with fasthttp's zero allocation model.

Also, I've noticed, parsing the response from `https://status.mojang.com/check` failed. The problem is, that you are trying to parse a JSON model which looks like following:
```json
[ { "string": "string" } ]
```
into an array of structs looking like this:
```go
[]struct{
    Key   string
    Value string
}
```
which actually would result in a model looking like following:
```
[ { "Key": "string", "Value": "string" } ]
```

So, I solved this by using an array of maps. After iterating through the array of maps, I iterate into the key value pairs of the map *(which is always be expected to be one single pair)* and then entering the switch case block depending on the key and value of the entry of the map.

Hope this PR is kinda helpful. :)